### PR TITLE
typo: capit -> capita

### DIFF
--- a/data/indicators-final.json
+++ b/data/indicators-final.json
@@ -2613,7 +2613,7 @@
     "goal_meta_link_page": 2,
     "target": "Sustain per capita economic growth in accordance with national circumstances and, in particular, at least 7 per cent gross domestic product growth per annum in the least developed countries.",
     "indicator_id": "8.1.1",
-    "indicator": "Annual growth rate of real GDP per capit"
+    "indicator": "Annual growth rate of real GDP per capita"
   },
   {
     "target_id": "8.2",


### PR DESCRIPTION
There was a typo where `capit` should be `capita` in `data/indicators-final.json`

~~~
   "indicator_id": "8.1.1",
    "indicator": "Annual growth rate of real GDP per capit"
~~~